### PR TITLE
fix: rename GPS to GNSS

### DIFF
--- a/src/@types/aws-device.d.ts
+++ b/src/@types/aws-device.d.ts
@@ -1,12 +1,12 @@
 import {
-	DeviceConfig,
-	Gps,
 	Battery,
+	DeviceConfig,
 	DeviceInformation,
-	RoamingInformation,
 	Environment,
-	ReportedState,
+	Gnss,
 	MakeReceivedProperty,
+	ReportedState,
+	RoamingInformation,
 } from './device-state'
 
 export type AWSDeviceInformation = DeviceInformation & {
@@ -17,7 +17,7 @@ export type AWSDeviceInformation = DeviceInformation & {
 
 export type ReportedThingState = {
 	cfg?: Partial<DeviceConfig>
-	gps?: Gps
+	gnss?: Gnss
 	bat?: Battery
 	dev?: AWSDeviceInformation
 	roam?: RoamingInformation

--- a/src/@types/azure-device.ts
+++ b/src/@types/azure-device.ts
@@ -1,12 +1,12 @@
 import {
-	DeviceConfig,
-	Gps,
 	Battery,
+	DeviceConfig,
 	DeviceInformation,
-	RoamingInformation,
 	Environment,
+	Gnss,
 	MakeReceivedProperty,
 	ReportedState,
+	RoamingInformation,
 } from './device-state'
 
 export type PropertyMetadata = Record<string, any> & {
@@ -52,7 +52,7 @@ export type MakePropertyMetadata<Type> = {
 
 export type DeviceTwinReported = {
 	cfg?: Partial<DeviceConfig>
-	gps?: Gps
+	gnss?: Gnss
 	bat?: Battery
 	dev?: DeviceInformation
 	roam?: RoamingInformation
@@ -60,7 +60,7 @@ export type DeviceTwinReported = {
 	firmware?: AzureFOTAJobProgress
 	$metadata: PropertyMetadata & {
 		cfg?: PropertyMetadata & MakePropertyMetadata<DeviceConfig>
-		gps?: PropertyMetadata & MakePropertyMetadata<Gps>
+		gnss?: PropertyMetadata & MakePropertyMetadata<Gnss>
 		bat?: PropertyMetadata & MakePropertyMetadata<Battery>
 		dev?: PropertyMetadata & MakePropertyMetadata<DeviceInformation>
 		roam?: PropertyMetadata & MakePropertyMetadata<RoamingInformation>

--- a/src/@types/device-state.ts
+++ b/src/@types/device-state.ts
@@ -8,12 +8,12 @@ export type DeviceConfig = {
 	actwt: number
 	mvres: number
 	mvt: number
-	gpst: number
+	gnsst: number
 	acct: number
 	nod: DataModules[]
 }
 
-export type Gps = {
+export type Gnss = {
 	v: {
 		lat: number
 		lng: number
@@ -70,7 +70,7 @@ export type MakeReceivedProperty<Type> = {
 }
 
 export type ReportedConfigState = Partial<MakeReceivedProperty<DeviceConfig>>
-export type ReportedGps = MakeReceivedProperty<Gps>
+export type ReportedGnss = MakeReceivedProperty<Gnss>
 export type ReportedBattery = MakeReceivedProperty<Battery>
 export type ReportedEnvironment = MakeReceivedProperty<Environment>
 export type ReportedDeviceInformation = MakeReceivedProperty<DeviceInformation>
@@ -79,7 +79,7 @@ export type ReportedRoamingInformation =
 
 export type ReportedState = {
 	cfg?: ReportedConfigState
-	gps?: ReportedGps
+	gnss?: ReportedGnss
 	bat?: ReportedBattery
 	dev?: ReportedDeviceInformation
 	roam?: ReportedRoamingInformation

--- a/src/Settings/NumberConfigSetting.tsx
+++ b/src/Settings/NumberConfigSetting.tsx
@@ -1,3 +1,4 @@
+import { formatDistanceToNow } from 'date-fns'
 import React, { useState } from 'react'
 import {
 	FormGroup,
@@ -7,9 +8,8 @@ import {
 	InputGroupText,
 	Label,
 } from 'reactstrap'
-import { OutDatedWarning } from './OutDatedWarning'
-import { formatDistanceToNow } from 'date-fns'
 import { emojify } from '../Emojify/Emojify'
+import { OutDatedWarning } from './OutDatedWarning'
 
 export const NumberConfigSetting = ({
 	label,
@@ -29,7 +29,7 @@ export const NumberConfigSetting = ({
 	unit?: string
 	example?: number
 	step?: number
-	id: 'actwt' | 'mvres' | 'mvt' | 'gpst' | 'acct'
+	id: 'actwt' | 'mvres' | 'mvt' | 'gnsst' | 'acct'
 	onChange: (v: string) => any
 	desired?: number
 	reported?: {

--- a/src/Settings/Settings.tsx
+++ b/src/Settings/Settings.tsx
@@ -1,18 +1,18 @@
-import React, { useState } from 'react'
-import { Button, ButtonGroup, Form, FormGroup, Alert } from 'reactstrap'
-import equal from 'fast-deep-equal'
-import { OutDatedWarning } from './OutDatedWarning'
-import { NumberConfigSetting } from './NumberConfigSetting'
 import { formatDistanceToNow } from 'date-fns'
-import { emojify } from '../Emojify/Emojify'
+import equal from 'fast-deep-equal'
+import { default as introJs } from 'intro.js'
+import React, { useState } from 'react'
+import { Alert, Button, ButtonGroup, Form, FormGroup } from 'reactstrap'
 import styled from 'styled-components'
-import { mobileBreakpoint } from '../Styles'
 import {
 	DataModules,
 	DeviceConfig,
 	ReportedConfigState,
 } from '../@types/device-state'
-import { default as introJs } from 'intro.js'
+import { emojify } from '../Emojify/Emojify'
+import { mobileBreakpoint } from '../Styles'
+import { NumberConfigSetting } from './NumberConfigSetting'
+import { OutDatedWarning } from './OutDatedWarning'
 
 const intro = introJs()
 
@@ -209,14 +209,14 @@ export const Settings = ({
 						</ButtonGroup>
 					</FormGroup>
 				</fieldset>
-				<fieldset data-intro={'How long to try to acquire a GPS fix.'}>
-					<legend>GPS Timeout</legend>
+				<fieldset data-intro={'How long to try to acquire a GNSS fix.'}>
+					<legend>GNSS Timeout</legend>
 					<NumberConfigSetting
-						id={'gpst'}
-						desired={newDesired.gpst}
-						reported={r.gpst}
+						id={'gnsst'}
+						desired={newDesired.gnsst}
+						reported={r.gnsst}
 						example={60}
-						onChange={updateConfigProperty('gpst')}
+						onChange={updateConfigProperty('gnsst')}
 						minimum={1}
 						maximum={MAX_INT32}
 					/>
@@ -270,7 +270,7 @@ export const Settings = ({
 					<NumberConfigSetting
 						label={'Active Wait Time'}
 						intro={
-							'Wait this amount of seconds until sending the next update. The actual interval will be this time plus the time it takes to get a GPS fix.'
+							'Wait this amount of seconds until sending the next update. The actual interval will be this time plus the time it takes to get a GNSS fix.'
 						}
 						id={'actwt'}
 						desired={newDesired.actwt}
@@ -284,7 +284,7 @@ export const Settings = ({
 				<fieldset data-intro={'This sets which Data Modules to sample.'}>
 					<legend>Data Sampling</legend>
 					<FormGroup>
-						<label>GPS: </label>
+						<label>GNSS:</label>
 						<ButtonGroup>
 							<OutDatedWarning
 								desired={newDesired.nod}
@@ -314,7 +314,7 @@ export const Settings = ({
 							<Button
 								color={'success'}
 								data-intro={
-									'In <em>Enabled</em> mode, the tracker will use GPS to send location data to the cloud.'
+									'In <em>Enabled</em> mode, the tracker will use GNSS to send location data to the cloud.'
 								}
 								outline={newDesired.nod?.includes(DataModules.GNSS)}
 								onClick={() => {
@@ -330,7 +330,7 @@ export const Settings = ({
 							<Button
 								color={'danger'}
 								data-intro={
-									'In <em>Disabled</em> mode, the tracker will not use GPS to send location data to the cloud.'
+									'In <em>Disabled</em> mode, the tracker will not use GNSS to send location data to the cloud.'
 								}
 								outline={
 									newDesired.nod === undefined ||

--- a/src/aws/Cat/Cat.tsx
+++ b/src/aws/Cat/Cat.tsx
@@ -1,27 +1,27 @@
-import { default as introJs } from 'intro.js'
-import { FOTA, OnCreateUpgradeJob } from '../FOTA/FOTA'
-import { DeviceUpgradeFirmwareJob } from '../listUpgradeFirmwareJobs'
 import { ICredentials } from '@aws-amplify/core'
+import { isSome, Option } from 'fp-ts/lib/Option'
+import { default as introJs } from 'intro.js'
 import React, { useEffect, useState } from 'react'
 import { Card, CardBody, CardHeader } from 'reactstrap'
-import { DisplayError } from '../../Error/Error'
-import { Toggle } from '../../Toggle/Toggle'
-import { ConnectionInformation } from '../../ConnectionInformation/ConnectionInformation'
-import { emojify } from '../../Emojify/Emojify'
-import { ReportedTime } from '../../ReportedTime/ReportedTime'
-import { Collapsable } from '../../Collapsable/Collapsable'
-import { DeviceInfo } from '../../DeviceInformation/DeviceInformation'
-import { CatCard } from '../../Cat/CatCard'
-import { CollapsedContextConsumer } from '../../Collapsable/CollapsedContext'
-import {
-	MobileOnlyCatHeader,
-	CatPersonalization,
-} from '../../Cat/CatPersonality'
 import { ThingState } from '../../@types/aws-device'
 import { DeviceConfig } from '../../@types/device-state'
+import { CatCard } from '../../Cat/CatCard'
+import {
+	CatPersonalization,
+	MobileOnlyCatHeader,
+} from '../../Cat/CatPersonality'
+import { Collapsable } from '../../Collapsable/Collapsable'
+import { CollapsedContextConsumer } from '../../Collapsable/CollapsedContext'
+import { ConnectionInformation } from '../../ConnectionInformation/ConnectionInformation'
+import { DeviceInfo } from '../../DeviceInformation/DeviceInformation'
+import { emojify } from '../../Emojify/Emojify'
+import { DisplayError } from '../../Error/Error'
+import { ReportedTime } from '../../ReportedTime/ReportedTime'
 import { Settings } from '../../Settings/Settings'
+import { Toggle } from '../../Toggle/Toggle'
+import { FOTA, OnCreateUpgradeJob } from '../FOTA/FOTA'
+import { DeviceUpgradeFirmwareJob } from '../listUpgradeFirmwareJobs'
 import { toReportedWithReceivedAt } from '../toReportedWithReceivedAt'
-import { Option, isSome } from 'fp-ts/lib/Option'
 
 const intro = introJs()
 
@@ -152,7 +152,7 @@ export const Cat = ({
 		(state?.reported.cfg?.act ?? true // default device mode is active
 			? state?.reported.cfg?.actwt ?? 120 // default active wait time is 120 seconds
 			: state?.reported.cfg?.mvt ?? 3600) + // default movement timeout is 3600
-		(state?.reported.cfg?.gpst ?? 60) + // default GPS timeout is 60 seconds
+		(state?.reported.cfg?.gnsst ?? 60) + // default GNSS timeout is 60 seconds
 		60 // add 1 minute for sending and processing
 
 	return (
@@ -186,23 +186,25 @@ export const Cat = ({
 								/>
 							</Toggle>
 						)}
-						{(reportedWithReceived?.gps?.v?.value?.spd !== undefined ||
-							reportedWithReceived?.gps?.v?.value?.alt !== undefined) && (
+						{(reportedWithReceived?.gnss?.v?.value?.spd !== undefined ||
+							reportedWithReceived?.gnss?.v?.value?.alt !== undefined) && (
 							<Toggle>
 								<div className={'info'}>
-									{reportedWithReceived.gps.v.value.spd !== undefined &&
+									{reportedWithReceived.gnss.v.value.spd !== undefined &&
 										emojify(
 											` 🏃${Math.round(
-												reportedWithReceived.gps.v.value.spd,
+												reportedWithReceived.gnss.v.value.spd,
 											)}m/s`,
 										)}
-									{reportedWithReceived.gps.v.value.alt !== undefined &&
+									{reportedWithReceived.gnss.v.value.alt !== undefined &&
 										emojify(
-											`✈️ ${Math.round(reportedWithReceived.gps.v.value.alt)}m`,
+											`✈️ ${Math.round(
+												reportedWithReceived.gnss.v.value.alt,
+											)}m`,
 										)}
 									<ReportedTime
-										receivedAt={reportedWithReceived.gps.v.receivedAt}
-										reportedAt={new Date(reportedWithReceived.gps.ts.value)}
+										receivedAt={reportedWithReceived.gnss.v.receivedAt}
+										reportedAt={new Date(reportedWithReceived.gnss.ts.value)}
 										staleAfterSeconds={expectedSendIntervalInSeconds}
 									/>
 								</div>

--- a/src/aws/Cat/CatMap.tsx
+++ b/src/aws/Cat/CatMap.tsx
@@ -1,14 +1,14 @@
-import { Location, CellLocation, Roaming } from '../../Map/Map'
-import React, { useState, useEffect } from 'react'
+import { isRight } from 'fp-ts/lib/Either'
+import { isSome, Option } from 'fp-ts/lib/Option'
+import React, { useEffect, useState } from 'react'
+import { ThingState } from '../../@types/aws-device'
+import { NCellMeasReport } from '../../@types/device-state'
+import { HistoricalDataMap } from '../../Map/HistoricalDataMap'
+import { CellLocation, Location, Roaming } from '../../Map/Map'
 import { TimestreamQueryContextType } from '../App'
 import { geolocateCell } from '../geolocateCell'
-import { isRight } from 'fp-ts/lib/Either'
-import { CatInfo } from './Cat'
-import { ThingState } from '../../@types/aws-device'
-import { HistoricalDataMap } from '../../Map/HistoricalDataMap'
-import { NCellMeasReport } from '../../@types/device-state'
-import { isSome, Option } from 'fp-ts/lib/Option'
 import { geolocatNeighboringCellReport } from '../geolocatNeighboringCellReport'
+import { CatInfo } from './Cat'
 
 export const CatMap = ({
 	timestreamQueryContext,
@@ -120,20 +120,20 @@ export const CatMap = ({
 	let deviceLocation: Location | undefined = undefined
 
 	if (
-		reported.gps?.v !== undefined &&
-		typeof reported.gps.v === 'object' &&
-		'lat' in reported.gps.v &&
-		'lng' in reported.gps.v
+		reported.gnss?.v !== undefined &&
+		typeof reported.gnss.v === 'object' &&
+		'lat' in reported.gnss.v &&
+		'lng' in reported.gnss.v
 	) {
 		deviceLocation = {
-			ts: new Date(reported.gps.ts),
+			ts: new Date(reported.gnss.ts),
 			position: {
-				lat: reported.gps.v.lat,
-				lng: reported.gps.v.lng,
-				accuracy: reported.gps.v.acc,
-				altitude: reported.gps.v.alt,
-				heading: reported.gps.v.hdg,
-				speed: reported.gps.v.spd,
+				lat: reported.gnss.v.lat,
+				lng: reported.gnss.v.lng,
+				accuracy: reported.gnss.v.acc,
+				altitude: reported.gnss.v.alt,
+				heading: reported.gnss.v.hdg,
+				speed: reported.gnss.v.spd,
 			},
 		}
 	}
@@ -164,12 +164,12 @@ export const CatMap = ({
 								measureGroup
 								FROM ${table}
 								WHERE deviceId='${cat.id}' 
-								AND substr(measure_name, 1, 4) = 'gps.'
+								AND substr(measure_name, 1, 4) = 'gnss.'
 								GROUP BY measureGroup, time
 								ORDER BY time DESC
 								LIMIT ${numEntries}
 							)
-							AND substr(measure_name, 1, 4) = 'gps.'
+							AND substr(measure_name, 1, 4) = 'gnss.'
 							GROUP BY measureGroup, time
 							ORDER BY time DESC`,
 					)

--- a/src/aws/CatsMap/Loader.tsx
+++ b/src/aws/CatsMap/Loader.tsx
@@ -1,12 +1,12 @@
-import React, { useEffect, useState } from 'react'
-import { IotConsumer } from '../App'
 import { IoTClient, ListThingsCommand } from '@aws-sdk/client-iot'
 import {
-	IoTDataPlaneClient,
 	GetThingShadowCommand,
+	IoTDataPlaneClient,
 } from '@aws-sdk/client-iot-data-plane'
-import { Map, CatLocation } from '../../CatsMap/Map'
 import { toUtf8 } from '@aws-sdk/util-utf8-browser'
+import React, { useEffect, useState } from 'react'
+import { CatLocation, Map } from '../../CatsMap/Map'
+import { IotConsumer } from '../App'
 
 const CatsMapLoader = ({
 	iot,
@@ -31,7 +31,7 @@ const CatsMapLoader = ({
 									return
 								}
 								const p = JSON.parse(toUtf8(payload))
-								const { lat, lng } = p.state.reported.gps.v
+								const { lat, lng } = p.state.reported.gnss.v
 								if (lat !== undefined && lng !== undefined) {
 									return {
 										id: thingName as string,

--- a/src/aws/toReportedWithReceivedAt.spec.ts
+++ b/src/aws/toReportedWithReceivedAt.spec.ts
@@ -5,7 +5,7 @@ describe('toReportedWithReceivedAt', () => {
 		expect(
 			toReportedWithReceivedAt({
 				reported: {
-					gps: {
+					gnss: {
 						v: {
 							lng: 10.437087,
 							lat: 63.42156,
@@ -22,7 +22,7 @@ describe('toReportedWithReceivedAt', () => {
 				},
 				metadata: {
 					reported: {
-						gps: {
+						gnss: {
 							v: {
 								lng: {
 									timestamp: 1564568351,
@@ -56,7 +56,7 @@ describe('toReportedWithReceivedAt', () => {
 				},
 			}),
 		).toEqual({
-			gps: {
+			gnss: {
 				v: {
 					value: {
 						lng: 10.437087,

--- a/src/aws/toReportedWithReceivedAt.ts
+++ b/src/aws/toReportedWithReceivedAt.ts
@@ -1,9 +1,9 @@
 import {
-	ThingStateMetadataProperty,
-	ReportedThingState,
 	AWSReportedState,
+	ReportedThingState,
+	ThingStateMetadataProperty,
 } from '../@types/aws-device'
-import { MakeReceivedProperty, DeviceConfig } from '../@types/device-state'
+import { DeviceConfig, MakeReceivedProperty } from '../@types/device-state'
 
 /**
  * AWS meta does not report timestamps for top level arrays or objects, so find the first timestamp in an array or nested object.
@@ -49,9 +49,9 @@ export const toReportedWithReceivedAt = ({
 				>,
 		  }
 		: undefined),
-	...(reported.gps !== undefined && metadata.reported.gps !== undefined
+	...(reported.gnss !== undefined && metadata.reported.gnss !== undefined
 		? {
-				gps: toReceivedProps(reported.gps, metadata.reported.gps),
+				gnss: toReceivedProps(reported.gnss, metadata.reported.gnss),
 		  }
 		: undefined),
 	...(reported.bat !== undefined && metadata.reported.bat !== undefined

--- a/src/azure/CatsMap/Loader.tsx
+++ b/src/azure/CatsMap/Loader.tsx
@@ -1,7 +1,7 @@
-import React, { useState, useEffect } from 'react'
-import { ApiClient } from '../api'
-import { Map, CatLocation } from '../../CatsMap/Map'
 import { isRight } from 'fp-ts/lib/Either'
+import React, { useEffect, useState } from 'react'
+import { CatLocation, Map } from '../../CatsMap/Map'
+import { ApiClient } from '../api'
 
 export const CatMapLoader = ({ apiClient }: { apiClient: ApiClient }) => {
 	const [cats, setCats] = useState([] as CatLocation[])
@@ -13,15 +13,15 @@ export const CatMapLoader = ({ apiClient }: { apiClient: ApiClient }) => {
 
 		apiClient
 			.queryHistoricalDeviceData(
-				'SELECT c.deviceId, MAX(c.timestamp) AS max_timestamp FROM c WHERE c.deviceUpdate.properties.reported.gps != null GROUP BY c.deviceId',
+				'SELECT c.deviceId, MAX(c.timestamp) AS max_timestamp FROM c WHERE c.deviceUpdate.properties.reported.gnss != null GROUP BY c.deviceId',
 			)
 			.then((res) => {
 				if (isRight(res)) {
-					const q = `SELECT c.deviceId, c.deviceUpdate.properties.reported.gps.v FROM c WHERE c.deviceId IN (${(
+					const q = `SELECT c.deviceId, c.deviceUpdate.properties.reported.gnss.v FROM c WHERE c.deviceId IN (${(
 						res.right.result as { deviceId: string }[]
 					).map(
 						(s) => `"${s.deviceId}"`,
-					)}) AND c.deviceUpdate.properties.reported.gps != null AND c.timestamp IN (${(
+					)}) AND c.deviceUpdate.properties.reported.gnss != null AND c.timestamp IN (${(
 						res.right.result as { max_timestamp: string }[]
 					).map((s) => `"${s.max_timestamp}"`)})`
 					return apiClient.queryHistoricalDeviceData(q).then((res) => {

--- a/src/azure/toReportedWithReceivedAt.spec.ts
+++ b/src/azure/toReportedWithReceivedAt.spec.ts
@@ -10,7 +10,7 @@ describe('toReportedWithReceivedAt', () => {
 				actwt: 103,
 				mvres: 300,
 				mvt: 3600,
-				gpst: 60,
+				gnsst: 60,
 				acct: 0.1,
 				nod: [DataModules.GNSS],
 			},
@@ -55,7 +55,7 @@ describe('toReportedWithReceivedAt', () => {
 					mvt: {
 						$lastUpdated: '2020-04-21T14:41:51.6278473Z',
 					},
-					gpst: {
+					gnsst: {
 						$lastUpdated: '2020-04-21T14:41:51.6278473Z',
 					},
 					acct: {
@@ -142,7 +142,7 @@ describe('toReportedWithReceivedAt', () => {
 			},
 			mvres: { value: 300, receivedAt: new Date('2020-04-21T14:41:51.627Z') },
 			mvt: { value: 3600, receivedAt: new Date('2020-04-21T14:41:51.627Z') },
-			gpst: { value: 60, receivedAt: new Date('2020-04-21T14:41:51.627Z') },
+			gnsst: { value: 60, receivedAt: new Date('2020-04-21T14:41:51.627Z') },
 			acct: { value: 0.1, receivedAt: new Date('2020-04-21T14:41:51.627Z') },
 			nod: {
 				value: [DataModules.GNSS],

--- a/src/azure/toReportedWithReceivedAt.ts
+++ b/src/azure/toReportedWithReceivedAt.ts
@@ -1,10 +1,10 @@
 import {
-	DeviceTwinReported,
-	PropertyMetadata,
-	MakePropertyMetadata,
 	AzureReportedState,
+	DeviceTwinReported,
+	MakePropertyMetadata,
+	PropertyMetadata,
 } from '../@types/azure-device'
-import { MakeReceivedProperty, DeviceConfig } from '../@types/device-state'
+import { DeviceConfig, MakeReceivedProperty } from '../@types/device-state'
 
 export const toReceivedProps = <A extends { [key: string]: any }>(
 	v: A,
@@ -36,9 +36,9 @@ export const toReportedWithReceivedAt = (
 					>,
 			  }
 			: undefined),
-		...(reported.gps !== undefined && $metadata.gps !== undefined
+		...(reported.gnss !== undefined && $metadata.gnss !== undefined
 			? {
-					gps: toReceivedProps(reported.gps, $metadata.gps),
+					gnss: toReceivedProps(reported.gnss, $metadata.gnss),
 			  }
 			: undefined),
 		...(reported.bat !== undefined && $metadata.bat !== undefined


### PR DESCRIPTION
The more generic term GNSS is used in favor of GPS.

See https://github.com/NordicSemiconductor/asset-tracker-cloud-docs/pull/352

BREAKING CHANGE: this requires firmware updates